### PR TITLE
Feat: 优化关注列表交互并修复取关失败,后台错误报错等问题

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -7,5 +7,5 @@ RESOURCE_CHANNEL_IDS="CHANNEL_ID_1,CHANNEL_ID_2"
 # SQLite 数据库文件名
 DB_NAME="follow_bot.db"
 
-# 添加你的测试服务器ID，这会让斜杠命令立即更新并清除旧命令
+# 添加你的服务器ID，这会让斜杠命令立即更新并清除旧命令
 TEST_GUILD_ID="YOUR_TEST_SERVER_ID"s

--- a/src/modules/user_profile_feature/cogs/user_commands.py
+++ b/src/modules/user_profile_feature/cogs/user_commands.py
@@ -1,13 +1,139 @@
 import discord
 from discord.ext import commands
 from discord import app_commands
-# 1. 修正导入路径，使用从 'src' 开始的绝对路径
-from src.modules.follow_feature.services.follow_service import FollowService
+from discord import ui
+import math
+import traceback # 1. 导入 traceback 用于更详细的错误输出
+from src.modules.follow_feature.services.follow_service import FollowService, UnfollowResult
+
+# --- 1. 使用重构后的 FollowsManageView 替换旧版本 ---
+class FollowsManageView(ui.View):
+    def __init__(self, follow_service: FollowService, user_id: int, followed_authors: list[dict]):
+        super().__init__(timeout=180)
+        self.follow_service = follow_service
+        self.user_id = user_id
+        self.all_authors = followed_authors
+        
+        self.current_page = 0
+        self.page_size = 1  # 每页显示10个作者
+        self.total_pages = math.ceil(len(self.all_authors) / self.page_size) if self.all_authors else 1
+
+        # 初始化时就构建好所有组件
+        self.update_components()
+
+    def get_current_page_authors(self) -> list[dict]:
+        """获取当前页的作者列表"""
+        start = self.current_page * self.page_size
+        end = start + self.page_size
+        return self.all_authors[start:end]
+
+    def create_embed(self, success_message: str = None) -> discord.Embed:
+        """根据当前页创建Embed"""
+        page_authors = self.get_current_page_authors()
+        
+        description_lines = []
+        if not page_authors:
+            description_lines.append("您还没有关注任何作者，或当前页没有作者了。")
+        else:
+            for author in page_authors:
+                new_post_count = author.get('new_posts', 0)
+                new_post_text = ""
+                if new_post_count > 0:
+                    new_post_text = f" - 📬 **{new_post_count}** 个新帖"
+                description_lines.append(f"• <@{author['author_id']}> (`{author['author_name']}`){new_post_text}")
+        
+        description = "从下面的菜单中选择一位作者进行取关。\n\n" + "\n".join(description_lines)
+        if success_message:
+            # 将成功消息添加到描述的顶部
+            description = f"{success_message}\n\n" + description
+
+        embed = discord.Embed(
+            title="我关注的作者列表",
+            description=description,
+            color=discord.Color.blue()
+        )
+        embed.set_footer(text=f"第 {self.current_page + 1} / {self.total_pages} 页")
+        return embed
+
+    def update_components(self):
+        """动态更新所有组件（下拉菜单和按钮）"""
+        self.clear_items()  # 清除旧的组件
+
+        page_authors = self.get_current_page_authors()
+        
+        # 只有在当前页有作者可选时，才创建并添加下拉菜单
+        if page_authors:
+            select_options = [
+                discord.SelectOption(label=author['author_name'], value=str(author['author_id']))
+                for author in page_authors
+            ]
+            select_menu = ui.Select(placeholder="选择一位作者进行取关...", options=select_options)
+            select_menu.callback = self.select_callback
+            self.add_item(select_menu)
+        # 如果没有作者，就不添加任何下拉菜单组件
+
+        # 按钮的逻辑保持不变，它们会根据页码自动禁用
+        prev_button = ui.Button(label="◀️ 上一页", style=discord.ButtonStyle.primary, disabled=(self.current_page == 0))
+        prev_button.callback = self.prev_page
+        self.add_item(prev_button)
+
+        next_button = ui.Button(label="下一页 ▶️", style=discord.ButtonStyle.primary, disabled=(self.current_page >= self.total_pages - 1))
+        next_button.callback = self.next_page
+        self.add_item(next_button)
+
+    async def select_callback(self, interaction: discord.Interaction):
+        """当用户从下拉菜单中选择一个选项时调用"""
+        # 1. 立刻延迟响应，这是解决“交互失败”的关键
+        #    使用 ephemeral=True 明确告知 Discord 这是一个临时消息的后续操作
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            author_id_to_unfollow = int(interaction.data['values'][0])
+            
+            # 2. 现在可以安全地执行可能耗时的数据库操作
+            result = await self.follow_service.unfollow_author(self.user_id, author_id_to_unfollow)
+            
+            if result == UnfollowResult.SUCCESS:
+                author_name = next((author['author_name'] for author in self.all_authors if author['author_id'] == author_id_to_unfollow), "未知作者")
+                
+                # 更新内部数据
+                self.all_authors = [author for author in self.all_authors if author['author_id'] != author_id_to_unfollow]
+                self.total_pages = math.ceil(len(self.all_authors) / self.page_size) if self.all_authors else 1
+                if self.current_page >= self.total_pages:
+                    self.current_page = max(0, self.total_pages - 1)
+                
+                # 更新界面组件
+                self.update_components()
+                success_msg = f"✅ 已成功取关 **{author_name}**。"
+                # 3. 使用 edit_original_response 更新原始消息，这是 defer 后的标准做法
+                await interaction.edit_original_response(embed=self.create_embed(success_msg), view=self)
+            else:  # NOT_FOLLOWED
+                self.update_components()
+                error_msg = "🤔 操作失败，您可能已经取关了这位作者。"
+                await interaction.edit_original_response(embed=self.create_embed(error_msg), view=self)
+        except Exception as e:
+            # 4. 添加错误捕获，如果中间任何步骤出错，都能给出反馈而不是直接失败
+            print(f"在 select_callback 中发生错误: {e}")
+            traceback.print_exc()
+            await interaction.edit_original_response(content="处理您的请求时发生了一个内部错误，请稍后再试。", embed=None, view=None)
+
+
+    async def prev_page(self, interaction: discord.Interaction):
+        """翻到上一页"""
+        self.current_page -= 1
+        self.update_components()
+        await interaction.response.edit_message(embed=self.create_embed(), view=self)
+
+    async def next_page(self, interaction: discord.Interaction):
+        """翻到下一页"""
+        self.current_page += 1
+        self.update_components()
+        await interaction.response.edit_message(embed=self.create_embed(), view=self)
+
 
 class UserProfileCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        # bot对象上已经附加了follow_service实例
         self.follow_service: FollowService = bot.follow_service
 
     # 2. 修改装饰器为 app_commands.command
@@ -15,33 +141,37 @@ class UserProfileCog(commands.Cog):
     @app_commands.command(name="我的关注", description="查看您关注的所有作者列表")
     async def my_follows(self, interaction: discord.Interaction):
         try:
-            # 4. 将 ctx.author.id 替换为 interaction.user.id
+            # 3. --- 全新的命令逻辑 ---
+            # a. 获取上次查看时间，并自动更新为现在。函数会返回上次的时间。
+            last_view_time = await self.bot.db.get_and_update_last_view(interaction.user.id)
+
+            # b. 获取关注的作者列表
             followed_authors = await self.follow_service.get_user_follows_details(interaction.user.id)
 
             if not followed_authors:
-                # 5. 将 ctx.respond 替换为 interaction.response.send_message
                 await interaction.response.send_message("您还没有关注任何作者。", ephemeral=True)
                 return
 
-            # 创建更详细的描述
-            description_lines = []
-            for author in followed_authors:
-                # 优先显示 <@id>，如果用户不在服务器，则会显示其在数据库中记录的名字
-                description_lines.append(f"• <@{author['author_id']}> (`{author['author_name']}`)")
-
-            # 注意：如果列表过长，可能会超过Discord Embed的限制。
-            # 对于超长列表，未来可以考虑使用分页视图（discord.ui.View）来优化。
-            embed = discord.Embed(
-                title="我关注的作者列表",
-                description="以下是您关注的所有作者：\n" + "\n".join(description_lines),
-                color=discord.Color.blue()
-            )
+            # c. 获取这些作者自上次查看以来的新帖计数
+            author_ids = [author['author_id'] for author in followed_authors]
+            new_post_counts = await self.bot.db.get_new_post_counts(author_ids, last_view_time)
             
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            # d. 将计数整合到作者信息中
+            new_post_counts_map = {item['author_id']: item['new_posts_count'] for item in new_post_counts}
+            for author in followed_authors:
+                author['new_posts'] = new_post_counts_map.get(author['author_id'], 0)
+            
+            # e. (可选优化) 将有新帖的作者排在前面
+            followed_authors.sort(key=lambda x: x.get('new_posts', 0), reverse=True)
+            
+            # f. 创建并发送视图
+            view = FollowsManageView(self.follow_service, interaction.user.id, followed_authors)
+            embed = view.create_embed()
+            await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
         except Exception as e:
             print(f"命令 /我的关注 执行失败: {e}")
+            traceback.print_exc() # 打印详细错误信息
             await interaction.response.send_message("哎呀，操作失败了，好像和数据库的连接出了点问题。请稍后再试或联系管理员。", ephemeral=True)
 
-# 2. setup 函数需要是异步的 (async)
 async def setup(bot: commands.Bot):
     await bot.add_cog(UserProfileCog(bot))


### PR DESCRIPTION
**问题描述**
旧版的 /我的关注 功能存在几个用户体验问题：
1.没有分页功能
2.当处于第一页或最后一页时，点击“上一页”或“下一页”按钮会导致“该交互失败”的错误，因为没有对无效操作进行反馈。
3.当通过下拉菜单取关作者时，如果后台操作稍有延迟，同样会因为没有及时响应而导致“该交互失败”。
4.当取关列表中的最后一位作者时，程序会因为尝试创建一个没有选项的下拉菜单而崩溃，并返回一个内部错误。
5.discord不允许bot在作者刚发布帖子时就进行消息发送,虽然功能触发,但后台报错

解决方案
本次更新通过创建并重构 FollowsManageView 视图，彻底解决了上述问题，提升了功能的健壮性和用户体验。

**主要变更**
设置分页功能
动态禁用按钮: “上一页”和“下一页”按钮现在会在不可用时自动变为灰色不可点击状态。
交互延迟响应: 在处理取关操作前，使用 interaction.response.defer() 来立即响应交互，防止因后台耗时操作导致超时失败。
修复取关逻辑: 修正了当取关最后一位作者后，视图更新时因下拉菜单为空而导致的程序崩溃问题。现在会平滑地移除下拉菜单组件。
优化用户反馈: 成功取关后，会显示明确的成功消息，并且列表会即时刷新，提供流畅的体验。
代码健壮性: 为 select_callback 添加了 try...except 块，以捕获任何意外错误，防止交互直接失败
设置幽灵提及延时